### PR TITLE
Fix issue #19: OpenVR half-sized render targets

### DIFF
--- a/src/cinder/vr/openvr/Hmd.cpp
+++ b/src/cinder/vr/openvr/Hmd.cpp
@@ -596,11 +596,8 @@ float Hmd::getFullFov() const
 
 ci::Area Hmd::getEyeViewport( ci::vr::Eye eye ) const
 {
-	auto size = mRenderTargetSize;
-	if( ci::vr::EYE_LEFT == eye ) {
-		return Area( 0, 0, size.x / 2, size.y );
-	}
-	return Area( ( size.x + 1 ) / 2, 0, size.x, size.y );
+	// The viewport is the same for both eyes
+	return Area( { 0, 0 }, mRenderTargetSize );
 }
 
 void Hmd::enableEye( ci::vr::Eye eye, ci::vr::CoordSys eyeMatrixMode )


### PR DESCRIPTION
In issue #19 I noted that the OpenVR viewports were too small by half.  It turns out that the code was indeed creating two full-size render targets, but only using half of each of them. The fix is simple, and the result in the Vive headset looks about...twice as good!  (-;